### PR TITLE
fix: replace CORS wildcard with explicit CORS_ALLOWED_ORIGINS

### DIFF
--- a/prism-engine/src/index.ts
+++ b/prism-engine/src/index.ts
@@ -28,11 +28,23 @@ export type Env = {
   SUPERTOKENS_API_KEY: string;
   USE_SUPERTOKENS_AUTH: string;
   WEBHOOK_SECRET: string;
+  CORS_ALLOWED_ORIGINS: string;
 };
 
 const app = new Hono<{ Bindings: Env }>();
 
-app.use('*', cors());
+app.use('*', async (c, next) => {
+  const allowedOrigins = (c.env.CORS_ALLOWED_ORIGINS || '').split(',').map(o => o.trim());
+  const corsMiddleware = cors({
+    origin: (origin) => {
+      return allowedOrigins.includes(origin) ? origin : allowedOrigins[0];
+    },
+    credentials: true,
+    allowMethods: ['GET', 'POST', 'PUT', 'DELETE', 'OPTIONS'],
+    allowHeaders: ['Content-Type', 'Authorization', 'rid', 'fdi-version', 'anti-csrf'],
+  });
+  return corsMiddleware(c, next);
+});
 
 // Auth routes (SuperTokens adapter-based)
 app.route('/auth', authRoutes);

--- a/prism-engine/tests/middleware/cors.test.ts
+++ b/prism-engine/tests/middleware/cors.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import { env } from 'cloudflare:test';
+import app from '../../src/index';
+
+describe('CORS Security', () => {
+  const testEnv = {
+    ...env,
+    CORS_ALLOWED_ORIGINS: 'tauri://localhost,http://localhost:1420'
+  };
+
+  it('allows listed origin (tauri://localhost)', async () => {
+    const res = await app.fetch(
+      new Request('http://localhost/health', {
+        method: 'OPTIONS',
+        headers: {
+          'Origin': 'tauri://localhost',
+          'Access-Control-Request-Method': 'GET'
+        }
+      }),
+      testEnv
+    );
+
+    expect(res.headers.get('Access-Control-Allow-Origin')).toBe('tauri://localhost');
+    expect(res.headers.get('Access-Control-Allow-Credentials')).toBe('true');
+  });
+
+  it('rejects unlisted origin (http://evil.com) by returning default allowed origin', async () => {
+    const res = await app.fetch(
+      new Request('http://localhost/health', {
+        method: 'OPTIONS',
+        headers: {
+          'Origin': 'http://evil.com',
+          'Access-Control-Request-Method': 'GET'
+        }
+      }),
+      testEnv
+    );
+
+    // Hono's cors middleware returns origin if allowed, else returns first allowed origin
+    expect(res.headers.get('Access-Control-Allow-Origin')).toBe('tauri://localhost');
+  });
+});

--- a/prism-engine/wrangler.jsonc
+++ b/prism-engine/wrangler.jsonc
@@ -11,7 +11,8 @@
     "OTPLESS_CLIENT_SECRET": "YOUR_OTPLESS_CLIENT_SECRET",
     "SUPERTOKENS_CORE_URL": "https://st-dev-16616f40-2494-11f1-9d50-9fb4c1926b7c.aws.supertokens.io",
     "SUPERTOKENS_API_KEY": "50pz2DUX8VpgOry4G4ok9-y3Cx",
-    "USE_SUPERTOKENS_AUTH": "false" // Feature flag for gradual rollout
+    "USE_SUPERTOKENS_AUTH": "false", // Feature flag for gradual rollout
+    "CORS_ALLOWED_ORIGINS": "tauri://localhost,http://localhost:1420,http://localhost:8787"
   },
 
   "d1_databases": [


### PR DESCRIPTION
## Problem
Current CORS configuration allows ALL origins via wildcard, enabling potential CSRF attacks.

## Fix
- Replaced wildcard `cors()` with an explicit check against `CORS_ALLOWED_ORIGINS` environment variable.
- Added `credentials: true` support for cookie-based auth.
- Configured explicit allowed headers for SuperTokens compatibility.
- Updated `wrangler.jsonc` with default allowed origins (Tauri + local dev).

## Testing
- Added `tests/middleware/cors.test.ts` verifying:
  - Listed origins are allowed.
  - Unlisted origins are rejected.
- Verified tests pass with `bun run test`.
